### PR TITLE
Find method respects relationships, fixes #13

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -167,7 +167,7 @@ export default class Model extends StaticModel {
     return this
   }
 
-  /** 
+  /**
    * Result
    */
 
@@ -191,6 +191,10 @@ export default class Model extends StaticModel {
     }
 
     let url = `${this.baseURL()}/${this.resource()}/${identifier}${this._builder.query()}`
+
+    if ('_fromResource' in this) {
+      url = `${this._fromResource}/${identifier}${this._builder.query()}`
+    }
 
     return this.request({
       url,

--- a/src/Model.js
+++ b/src/Model.js
@@ -189,12 +189,8 @@ export default class Model extends StaticModel {
     if (identifier === undefined) {
       throw new Error('You must specify the param on find() method.')
     }
-
-    let url = `${this.baseURL()}/${this.resource()}/${identifier}${this._builder.query()}`
-
-    if ('_fromResource' in this) {
-      url = `${this._fromResource}/${identifier}${this._builder.query()}`
-    }
+    let base = this._fromResource || `${this.baseURL()}/${this.resource()}`
+    let url = `${base}/${identifier}${this._builder.query()}`
 
     return this.request({
       url,

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -325,6 +325,20 @@ describe('Model methods', () => {
     posts = await user.posts().get()
   })
 
+  test('a request from hasMany() with a find() hits right resource', async () => {
+    let user
+    let post
+
+    axiosMock.onAny().reply((config) => {
+      expect(config.method).toEqual('get')
+      expect(config.url).toEqual('http://localhost/users/1/posts/1')
+      return [200, {}]
+    })
+
+    user = new User({ id: 1 })
+    post = await user.posts().find(1)
+  })
+
   test('a request hasMany() method returns a array of Models', async () => {
 
     axiosMock.onGet('http://localhost/users/1/posts').reply(200, postsResponse)


### PR DESCRIPTION
A model `find` should respect the relationship parent when called on leaf model.
Example:

`user.posts().find(1)` should query `/users/1/posts/1`, not `/posts/1`