### PR TITLE
Model: .for() should use object.getPrimaryKey() instead of object.id

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -69,7 +69,7 @@ export default class Model extends StaticModel {
       throw new Error('The object referenced on for() method is not a valid Model.')
     }
 
-    if (!this.isValidId(object.id)) {
+    if (!this.isValidId(object.getPrimaryKey())) {
       throw new Error('The object referenced on for() method has a invalid id.')
     }
 


### PR DESCRIPTION
There is a small hickup regarding the implementation of getPrimaryKey() in the project. This will fix it: .for() uses object.id directly instead of calling getPrimaryKey().