### PR TITLE
Added ability to customize query parameter names

### DIFF
--- a/src/Builder.js
+++ b/src/Builder.js
@@ -15,12 +15,8 @@ export default class Builder {
     this.limitValue = null
     this.payload = null
 
-    this.fields = {
-      fields: {}
-    }
-    this.filters = {
-      filter: {}
-    }
+    this.fields = {}
+    this.filters = {}
 
     this.parser = new Parser(this)
   }
@@ -53,13 +49,13 @@ export default class Builder {
 
     // single entity .select(['age', 'firstname'])
     if (fields[0].constructor === String || fields[0].constructor === Array) {
-      this.fields.fields[this.model.resource()] = fields.join(',')
+      this.fields[this.model.resource()] = fields.join(',')
     }
 
     // related entities .select({ posts: ['title', 'content'], user: ['age', 'firstname']} )
     if (fields[0].constructor === Object) {
       Object.entries(fields[0]).forEach(([key, value]) => {
-        this.fields.fields[key] = value.join(',')
+        this.fields[key] = value.join(',')
       })
     }
 
@@ -73,7 +69,7 @@ export default class Builder {
     if (Array.isArray(value) || value instanceof Object)
       throw new Error('The VALUE must be primitive on where() method.')
 
-    this.filters.filter[key] = value
+    this.filters[key] = value
 
     return this
   }
@@ -82,7 +78,7 @@ export default class Builder {
     if (!Array.isArray(array))
       throw new Error('The second argument on whereIn() method must be an array.')
 
-    this.filters.filter[key] = array.join(',')
+    this.filters[key] = array.join(',')
 
     return this
   }

--- a/src/Model.js
+++ b/src/Model.js
@@ -119,6 +119,18 @@ export default class Model extends StaticModel {
     }
   }
 
+  parameterNames () {
+    return {
+      include: 'include',
+      filter: 'filter',
+      sort: 'sort',
+      fields: 'fields',
+      append: 'append',
+      page: 'page',
+      limit: 'limit'
+    }
+  }
+
   /**
    *  Query
    */

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -38,11 +38,11 @@ export default class Parser {
   }
 
   hasFields () {
-    return Object.keys(this.builder.fields.fields).length > 0
+    return Object.keys(this.builder.fields).length > 0
   }
 
   hasFilters () {
-    return Object.keys(this.builder.filters.filter).length > 0
+    return Object.keys(this.builder.filters).length > 0
   }
 
   hasSorts () {
@@ -65,6 +65,10 @@ export default class Parser {
     return (this.uri === '') ? '?' : '&'
   }
 
+  parameterNames () {
+    return this.builder.model.parameterNames()
+  }
+
   /**
    * Parsers
    */
@@ -74,7 +78,7 @@ export default class Parser {
       return
     }
 
-    this.uri += this.prepend() + 'include=' + this.builder.includes
+    this.uri += this.prepend() + this.parameterNames().include + '=' + this.builder.includes
   }
 
   appends () {
@@ -82,7 +86,7 @@ export default class Parser {
       return
     }
 
-    this.uri += this.prepend() + 'append=' + this.builder.appends
+    this.uri += this.prepend() + this.parameterNames().append + '=' + this.builder.appends
   }
 
   fields () {
@@ -90,7 +94,8 @@ export default class Parser {
       return
     }
 
-    this.uri += this.prepend() + qs.stringify(this.builder.fields, { encode: false })
+    let fields = { [this.parameterNames().fields]: this.builder.fields }
+    this.uri += this.prepend() + qs.stringify(fields, { encode: false })
   }
 
   filters () {
@@ -98,7 +103,8 @@ export default class Parser {
       return
     }
 
-    this.uri += this.prepend() + qs.stringify(this.builder.filters, { encode: false })
+    let filters = { [this.parameterNames().filter]: this.builder.filters }
+    this.uri += this.prepend() + qs.stringify(filters, { encode: false })
   }
 
   sorts () {
@@ -106,7 +112,7 @@ export default class Parser {
       return
     }
 
-    this.uri += this.prepend() + 'sort=' + this.builder.sorts
+    this.uri += this.prepend() + this.parameterNames().sort + '=' + this.builder.sorts
   }
 
   page () {
@@ -114,7 +120,7 @@ export default class Parser {
       return
     }
 
-    this.uri += this.prepend() + 'page=' + this.builder.pageValue
+    this.uri += this.prepend() + this.parameterNames().page + '=' + this.builder.pageValue
   }
 
   limit () {
@@ -122,7 +128,7 @@ export default class Parser {
       return
     }
 
-    this.uri += this.prepend() + 'limit=' + this.builder.limitValue
+    this.uri += this.prepend() + this.parameterNames().limit + '=' + this.builder.limitValue
   }
 
   payload () {

--- a/tests/builder.test.js
+++ b/tests/builder.test.js
@@ -1,4 +1,5 @@
 import Post from './dummy/models/Post'
+import ModelWithParamNames from './dummy/models/ModelWithParamNames';
 import { Model } from '../src'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter';
@@ -36,6 +37,25 @@ describe('Query builder', () => {
     expect(post._builder.query()).toEqual(query)
   })
 
+  test('it builds a complex query with custom param names', () => {
+    const post = ModelWithParamNames
+      .include('user')
+      .append('likes')
+      .select({
+        posts: ['title', 'content'],
+        user: ['age', 'firstname']
+      })
+      .where('title', 'Cool')
+      .where('status', 'ACTIVE')
+      .page(3)
+      .limit(10)
+      .orderBy('created_at')
+
+    const query = '?include_custom=user&append_custom=likes&fields_custom[posts]=title,content&fields_custom[user]=age,firstname&filter_custom[title]=Cool&filter_custom[status]=ACTIVE&sort_custom=created_at&page_custom=3&limit_custom=10'
+
+    expect(post._builder.query()).toEqual(query)
+  })
+
   test('include() sets properly the builder', () => {
     let post = Post.include('user')
 
@@ -69,11 +89,11 @@ describe('Query builder', () => {
   test('where() sets properly the builder', () => {
     let post = Post.where('id', 1)
 
-    expect(post._builder.filters.filter).toEqual({ id: 1 })
+    expect(post._builder.filters).toEqual({ id: 1 })
 
     post = Post.where('id', 1).where('title', 'Cool')
 
-    expect(post._builder.filters.filter).toEqual({ id: 1, title: 'Cool' })
+    expect(post._builder.filters).toEqual({ id: 1, title: 'Cool' })
   })
 
   test('where() throws a exception when doest not have params or only first param', () => {
@@ -101,7 +121,7 @@ describe('Query builder', () => {
   test('whereIn() sets properly the builder', () => {
     let post = Post.whereIn('status', ['ACTIVE', 'ARCHIVED'])
 
-    expect(post._builder.filters.filter).toEqual({ status: 'ACTIVE,ARCHIVED' })
+    expect(post._builder.filters).toEqual({ status: 'ACTIVE,ARCHIVED' })
   })
 
   test('whereIn() throws a exception when second parameter is not a array', () => {
@@ -152,7 +172,7 @@ describe('Query builder', () => {
   test('select() for single entity', () => {
     let post = Post.select('age', 'firstname')
 
-    expect(post._builder.fields.fields.posts).toEqual('age,firstname')
+    expect(post._builder.fields.posts).toEqual('age,firstname')
   })
 
   test('select() for related entities', () => {
@@ -161,8 +181,8 @@ describe('Query builder', () => {
       user: ['age', 'firstname']
     })
 
-    expect(post._builder.fields.fields.posts).toEqual('title,content')
-    expect(post._builder.fields.fields.user).toEqual('age,firstname')
+    expect(post._builder.fields.posts).toEqual('title,content')
+    expect(post._builder.fields.user).toEqual('age,firstname')
   })
 
   test('params() sets properly the builder', () => {

--- a/tests/dummy/models/ModelWithParamNames.js
+++ b/tests/dummy/models/ModelWithParamNames.js
@@ -1,0 +1,17 @@
+import BaseModel from './BaseModel'
+
+export default class ModelWithParamNames extends BaseModel {
+
+  parameterNames () {
+    return {
+      include: 'include_custom',
+      filter: 'filter_custom',
+      sort: 'sort_custom',
+      fields: 'fields_custom',
+      append: 'append_custom',
+      page: 'page_custom',
+      limit: 'limit_custom'
+    }
+  }
+
+}


### PR DESCRIPTION
A problem mentioned in #31, #32, and #9 is that there is no way to change the parameter names used. Some developers customize the parameter names in [spatie/laravel-query-builder](https://github.com/spatie/laravel-query-builder) or (like me) use [spatie/laravel-json-api-paginate](https://github.com/spatie/laravel-json-api-paginate) to match the JSON API spec.

I've written a new test and made a small attempt at an implementation. It might not be the best way to do this but since you asked for a PR I figured this would be a good start to get the feature rolling.

The main change is that a model can extend the `parameterNames()` method to change the parameters like so:

```js
  parameterNames () {
    return {
      include: 'include_custom',
      filter: 'filter_custom',
      sort: 'sort_custom',
      fields: 'fields_custom',
      append: 'append_custom',
      page: 'page_custom',
      limit: 'limit_custom'
    }
  }
```