### PR TITLE
fields[0].constructor === Array

### DIFF
--- a/src/Builder.js
+++ b/src/Builder.js
@@ -52,7 +52,7 @@ export default class Builder {
     }
 
     // single entity .select(['age', 'firstname'])
-    if (fields[0].constructor === String || fields[0].constructor === Array) {
+    if (fields[0].constructor === String || Array.isArray(fields[0]) ) {
       this.fields.fields[this.model.resource()] = fields.join(',')
     }
 


### PR DESCRIPTION
"fields[0].constructor === Array" is not 100% reliable.  
It should be replaced by a simple Array.isArray().

I'm using vue-api-query in a nuxt environment with SSR enabled.
The behavior is quite strange: "fields[0].constructor === Array" fails only in dev mode AND server side only.

Please merge, it makes me waste a lot of time :-(