### PR TITLE
`custom()` now takes multiple arguments to build resource urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,19 @@ let latest = await Post
   .first()  
 ```
 
+The `custom()` method can be called with multiple arguments to build
+resource endpoints and hierarchies. Simply supply them in the correct order.
+Any combination of strings and models is possible.
+
+```js
+    let user = new User({ id: 1 })
+    let post = new Post()
+
+    // GET /users/1/posts/latest
+    const result = await Post.custom(user, post, 'latest').get()
+```
+
+
 # Full example
 
 **/models/Post.js**

--- a/src/Model.js
+++ b/src/Model.js
@@ -45,7 +45,40 @@ export default class Model extends StaticModel {
     return this[this.primaryKey()]
   }
 
-  custom(resource) {
+  custom(...args) {
+
+    if(args.length === 0) {
+      throw new Error('The custom() method takes a minimum of one argument.')
+    }
+
+    // It would be unintuitive for users to manage where the '/' has to be for
+    // multiple arguments. We don't need it for the first argument if it's
+    // a string, but subsequent string arguments need the '/' at the beginning.
+    // We handle this implementation detail here to simplify the readme.
+    let slash = '';
+    let resource = '';
+    
+    args.forEach(value => {
+      switch(true) {
+        case (typeof value === 'string'):
+          resource += slash + value.replace(/^\/+/, '');
+          break;
+        case (value instanceof Model):
+          resource += slash + value.resource();
+          
+          if(value.isValidId(value.getPrimaryKey())) {
+            resource += '/' + value.getPrimaryKey();
+          }
+          break;
+        default:
+          throw new Error('Arguments to custom() must be strings or instances of Model.')
+      }
+      
+      if( !slash.length ) {
+        slash = '/';
+      }
+    });
+    
     this._customResource = resource
 
     return this

--- a/src/StaticModel.js
+++ b/src/StaticModel.js
@@ -67,9 +67,9 @@ export default class StaticModel {
     return self
   }
 
-  static custom(resource) {
+  static custom(...args) {
     let self = this.instance()
-    self.custom(resource)
+    self.custom(...args)
 
     return self
   }

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -496,4 +496,20 @@ describe('Model methods', () => {
 
     expect(errorModel).toThrow('The object referenced on for() method has a invalid id.')
   })
+
+  test('it throws a error when a custom() parameter is not a valid Model or a string', () => {
+    
+    errorModel = () => {
+      const post = new Post({ text: 'Hello' }).custom()
+    }
+
+    expect(errorModel).toThrow('The custom() method takes a minimum of one argument.')
+    
+    errorModel = () => {
+      const user = new User({ name: 'Mary' })
+      const post = new Post({ text: 'Hello' }).custom(user, 'a-string', 42)
+    }
+
+    expect(errorModel).toThrow('Arguments to custom() must be strings or instances of Model.')
+  })
 })

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -311,6 +311,33 @@ describe('Model methods', () => {
     const post = await Post.custom('postz').first()
   })
 
+  test('custom() gracefully handles accidental / for string arguments', async () => {
+
+    axiosMock.onAny().reply((config) => {
+      expect(config.url).toBe('postz/recent')
+
+      return [200, {}]
+    })
+
+    const post = await Post.custom('/postz', 'recent').first()
+  })
+
+  test('custom() called with multiple objects/strings gets the correct resource', async () => {
+    let user
+    let comment
+
+    axiosMock.onAny().reply((config) => {
+      expect(config.method).toEqual('get')
+      expect(config.url).toEqual('users/1/postz/comments')
+
+      return [200, {}]
+    })
+
+    user = new User({ id: 1 })
+    comment = new Comment()
+    const result = await Comment.custom(user, 'postz', comment).get()
+  })
+
   test('a request from hasMany() method hits right resource', async () => {
     let user
     let posts


### PR DESCRIPTION
- added tests
- updated readme
- tested in local dev environment
- backwards compatible

This will resolve #16 as well.

This works for our use-cases, but please review on your end as well.

Previously, I created a workaround for us with a base class having a dynamic base path (see #36).  
This was restricted to a custom prefix per situation and not all that flexible.

This solution, together with `for()`, should work for all reasonable use-cases regarding nested resources.