### PR TITLE
Fix for $find to use a constructor on the result

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -266,7 +266,7 @@ export default class Model extends StaticModel {
 
     return this
       .find(identifier)
-      .then(response => response.data || response)
+      .then(response => new this.constructor(response.data || response))
   }
 
   get() {


### PR DESCRIPTION
Fixes the result of find not being able to use methods such as `save` because it wasn't using a constructor.