### PR TITLE
data wrapping, model hydratation and access to response instance

### DIFF
--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -31,6 +31,7 @@ describe('Model methods', () => {
     expect(errorModel).toThrow('You must specify the param on find() method.')
   })
 
+  // deprecated, use first()
   test('it throws a error when $find() has no parameters', () => {
     errorModel = () => {
       const post = Post.$find()
@@ -50,6 +51,7 @@ describe('Model methods', () => {
     expect(post).toBeInstanceOf(Post)
   })
 
+  // deprecated, use first()
   test('$first() returns first object in array as instance of such Model', async () => {
 
     axiosMock.onGet('http://localhost/posts').reply(200, postsEmbedResponse)
@@ -129,6 +131,7 @@ describe('Model methods', () => {
     expect(post).toBeInstanceOf(Post)
   })
 
+  // deprecated, use find()
   test('$find() handles request with "data" wrapper', async () => {
     axiosMock.onGet('http://localhost/posts/1').reply(200, postEmbedResponse)
 
@@ -137,6 +140,7 @@ describe('Model methods', () => {
     expect(post).toEqual(postEmbedResponse.data)
   })
 
+  // deprecated, use find()
   test('$find() handles request without "data" wrapper', async () => {
     axiosMock.onGet('http://localhost/posts/1').reply(200, postResponse)
 
@@ -320,6 +324,7 @@ describe('Model methods', () => {
     post.comments().get()
   })
 
+  // deprecated, use get()
   test('$get() fetch style request with "data" wrapper', async () => {
     axiosMock.onGet('http://localhost/posts').reply(200, postsEmbedResponse)
 
@@ -329,6 +334,7 @@ describe('Model methods', () => {
 
   })
 
+  // deprecated, use get()
   test('$get() fetch style request without "data" wrapper', async () => {
     axiosMock.onGet('http://localhost/posts').reply(200, postsEmbedResponse.data)
 
@@ -338,6 +344,7 @@ describe('Model methods', () => {
 
   })
 
+  // deprecated, use get()
   test('$get() hits right resource (nested object, custom PK)', async () => {
     Post.prototype['primaryKey'] = () => {
       return 'someId'

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -386,6 +386,118 @@ describe('Model methods', () => {
     await post.save()
   })
 
+  test('save() handles POST request without "data" wrapper and hydrates the model instance', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {}
+    }
+
+    let post
+
+    axiosMock.onAny().reply((config) => {
+      expect(config.method).toEqual('post')
+      expect(config.data).toEqual(JSON.stringify(post))
+      expect(config.url).toEqual('http://localhost/posts')
+
+      return [200, {
+        id: 1,
+        title: 'Cool!'
+      }]
+    })
+
+    post = new Post({ title: 'Cool!' })
+    let res = await post.save()
+    expect(post).toBeInstanceOf(Post)
+    expect(post).toEqual({ id: 1, title: 'Cool!' })
+    expect(res.status).toEqual(200)
+    expect(res.data).toEqual({ id: 1, title: 'Cool!' })
+  })
+
+  test('save() handles PUT request without "data" wrapper and hydrates the model instance', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {}
+    }
+    let post
+
+    axiosMock.onAny().reply((config) => {
+      expect(config.method).toEqual('put')
+      expect(config.data).toEqual(JSON.stringify(post))
+      expect(config.url).toEqual('http://localhost/posts/1')
+
+      return [200, {
+          id: 1,
+          title: 'Cool!',
+          body: 'Nice!',
+      }]
+    })
+
+    post = new Post({ id: 1, title: 'Cool!' })
+    let res = await post.save()
+    expect(post).toBeInstanceOf(Post)
+    expect(post).toEqual({ id: 1, title: 'Cool!', body: 'Nice!' })
+    expect(res.status).toEqual(200)
+    expect(res.data).toEqual({ id: 1, title: 'Cool!', body: 'Nice!' })
+  })
+
+  test('save() handles POST request with "data" wrapper and hydrates the model instance', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {
+        store: 'data'
+      }
+    }
+
+    let post
+
+    axiosMock.onAny().reply((config) => {
+      expect(config.method).toEqual('post')
+      expect(config.data).toEqual(JSON.stringify(post))
+      expect(config.url).toEqual('http://localhost/posts')
+
+      return [200, {
+        data: {
+          id: 1,
+          title: 'Cool!'
+        }
+      }]
+    })
+
+    post = new Post({ title: 'Cool!' })
+    let res = await post.save()
+    expect(post).toBeInstanceOf(Post)
+    expect(post).toEqual({ id: 1, title: 'Cool!' })
+    expect(res.status).toEqual(200)
+    expect(res.data).toEqual({ data: {id: 1, title: 'Cool!' }})
+  })
+
+  test('save() handles PUT request with "data" wrapper and hydrates the model instance', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {
+        update: 'data'
+      }
+    }
+    let post
+
+    axiosMock.onAny().reply((config) => {
+      expect(config.method).toEqual('put')
+      expect(config.data).toEqual(JSON.stringify(post))
+      expect(config.url).toEqual('http://localhost/posts/1')
+
+      return [200, {
+        data: {
+          id: 1,
+          title: 'Cool!',
+          body: 'Nice!',
+        }
+      }]
+    })
+
+    post = new Post({ id: 1, title: 'Cool!' })
+    let res = await post.save()
+    expect(post).toBeInstanceOf(Post)
+    expect(post).toEqual({ id: 1, title: 'Cool!', body: 'Nice!' })
+    expect(res.status).toEqual(200)
+    expect(res.data).toEqual({ data: { id: 1, title: 'Cool!', body: 'Nice!', }})
+  })
+
   test('save() method makes a PUT request when ID of object exists (custom PK)', async () => {
     Post.prototype['primaryKey'] = () => {
       return 'someId'

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -573,6 +573,56 @@ describe('Model methods', () => {
     post.delete()
   })
 
+  test('delete() handles request with "data" wrapper and hydrates model instance', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {
+        destroy: 'data'
+      }
+    }
+
+    axiosMock.onAny().reply((config) => {
+      expect(config.method).toEqual('delete')
+      expect(config.url).toBe('http://localhost/posts/1')
+
+      return [200, {
+        data: {
+          id: 1,
+          title: 'Cool!'
+        }
+      }]
+    })
+
+    const post = new Post({ id: 1 })
+    let res = await post.delete()
+    expect(post).toBeInstanceOf(Post)
+    expect(post).toEqual({ id: 1, title: 'Cool!' })
+    expect(res.status).toEqual(200)
+    expect(res.data).toEqual({ data: { id: 1, title: 'Cool!' }})
+  })
+
+  test('delete() handles request without "data" wrapper and hydrates model instance', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {}
+    }
+
+    axiosMock.onAny().reply((config) => {
+      expect(config.method).toEqual('delete')
+      expect(config.url).toBe('http://localhost/posts/1')
+
+      return [200, {
+        id: 1,
+        title: 'Cool!'
+      }]
+    })
+
+    const post = new Post({ id: 1 })
+    let res = await post.delete()
+    expect(post).toBeInstanceOf(Post)
+    expect(post).toEqual({ id: 1, title: 'Cool!' })
+    expect(res.status).toEqual(200)
+    expect(res.data).toEqual({ id: 1, title: 'Cool!' })
+  })
+
   test('a request from delete() method hits the right resource (custom PK)', async () => {
     Post.prototype['primaryKey'] = () => {
       return 'someId'

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -177,8 +177,9 @@ describe('Model methods', () => {
 
     const posts = await Post.get()
 
-    posts.forEach(post => {
+    posts.forEach((post, index) => {
       expect(post).toBeInstanceOf(Post)
+      expect(post).toEqual(postsResponse[index])
     });
   })
 
@@ -197,6 +198,114 @@ describe('Model methods', () => {
   test('get() hits right resource (nested object, custom PK)', async () => {
     Post.prototype['primaryKey'] = () => {
       return 'someId'
+    }
+
+    let post = new Post({ id: 1, someId: 'po996-9dd18' })
+
+    axiosMock.onGet().reply((config) => {
+      expect(config.method).toEqual('get')
+      expect(config.url).toEqual(`http://localhost/posts/${post.someId}/comments`)
+
+      return [200, {}]
+    })
+
+    post.comments().get()
+  })
+
+  test('get() method handles request without "data" wrapper and returns a array of objects as instance of suchModel', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {}
+    }
+
+    axiosMock.onGet('http://localhost/posts').reply(200, postsResponse)
+
+    const posts = await Post.get()
+
+    posts.forEach((post, index) => {
+      expect(post).toBeInstanceOf(Post)
+      expect(post).toEqual(postsResponse[index])
+    });
+  })
+
+  test('get() handles request without "data" wrapper and hits right resource (nested object)', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {}
+    }
+
+    axiosMock.onGet().reply((config) => {
+      expect(config.method).toEqual('get')
+      expect(config.url).toEqual('http://localhost/posts/1/comments')
+
+      return [200, {}]
+    })
+
+    const post = new Post({ id: 1 })
+    await post.comments().get()
+  })
+
+  test('get() handles request without "data" wrapper and hits right resource (nested object, custom PK)', async () => {
+    Post.prototype['primaryKey'] = () => {
+      return 'someId'
+    }
+    Post.prototype['dataWrappers'] = () => {
+      return {}
+    }
+
+    let post = new Post({ id: 1, someId: 'po996-9dd18' })
+
+    axiosMock.onGet().reply((config) => {
+      expect(config.method).toEqual('get')
+      expect(config.url).toEqual(`http://localhost/posts/${post.someId}/comments`)
+
+      return [200, {}]
+    })
+
+    post.comments().get()
+  })
+
+  test('get() method handles request with "data" wrapper and returns a array of objects as instance of suchModel', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {
+        index: 'data'
+      }
+    }
+
+    axiosMock.onGet('http://localhost/posts').reply(200, postsEmbedResponse)
+
+    const posts = await Post.get()
+
+    posts.forEach((post, index) => {
+      expect(post).toBeInstanceOf(Post)
+      expect(post).toEqual(postsEmbedResponse.data[index])
+    });
+  })
+
+  test('get() handles request with "data" wrapper and hits right resource (nested object)', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {
+        index: 'data'
+      }
+    }
+
+    axiosMock.onGet().reply((config) => {
+      expect(config.method).toEqual('get')
+      expect(config.url).toEqual('http://localhost/posts/1/comments')
+
+      return [200, {}]
+    })
+
+    const post = new Post({ id: 1 })
+    await post.comments().get()
+  })
+
+  test('get() handles request with "data" wrapper and hits right resource (nested object, custom PK)', async () => {
+    Post.prototype['primaryKey'] = () => {
+      return 'someId'
+    }
+    Post.prototype['dataWrappers'] = () => {
+      return {
+        index: 'data'
+      }
     }
 
     let post = new Post({ id: 1, someId: 'po996-9dd18' })

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -67,6 +67,60 @@ describe('Model methods', () => {
     expect(post).toEqual({})
   })
 
+  test('first() handles request without "data" wrapper and returns first object in array as instance of such Model', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {}
+    }
+
+    axiosMock.onGet('http://localhost/posts').reply(200, {
+      data: postsResponse
+    })
+
+    const post = await Post.first()
+    expect(post).toEqual(postsResponse[0])
+    expect(post).toBeInstanceOf(Post)
+  })
+
+  test('first() handles request without "data" wrapper and method returns a empty object when no items have found', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {}
+    }
+
+    axiosMock.onGet('http://localhost/posts').reply(200, [])
+
+    const post = await Post.first()
+    expect(post).toEqual({})
+  })
+
+  test('first() handles request with "data" wrapper and returns first object in array as instance of such Model', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {
+        index: 'data'
+      }
+    }
+
+    axiosMock.onGet('http://localhost/posts').reply(200, {
+      data: postsEmbedResponse
+    })
+
+    const post = await Post.first()
+    expect(post).toEqual(postsEmbedResponse['data'][0])
+    expect(post).toBeInstanceOf(Post)
+  })
+
+  test('first() handles request with "data" wrapper and method returns a empty object when no items have found', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {
+        index: 'data'
+      }
+    }
+
+    axiosMock.onGet('http://localhost/posts').reply(200, [])
+
+    const post = await Post.first()
+    expect(post).toEqual({})
+  })
+
   test('find() method returns a object as instance of such Model', async () => {
     axiosMock.onGet('http://localhost/posts/1').reply(200, postResponse)
 

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -145,6 +145,33 @@ describe('Model methods', () => {
     expect(post).toEqual(postResponse)
   })
 
+  test('find() handles request without "data" wrapper and returns a object as instance of such Model', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {}
+    }
+
+    axiosMock.onGet('http://localhost/posts/1').reply(200, postResponse)
+
+    const post = await Post.find(1)
+
+    expect(post).toEqual(postResponse)
+    expect(post).toBeInstanceOf(Post)
+  })
+
+  test('find() handles request with "data" wrapper and returns a object as instance of such Model', async () => {
+    Post.prototype['dataWrappers'] = () => {
+      return {
+        show: 'data'
+      }
+    }
+
+    axiosMock.onGet('http://localhost/posts/1').reply(200, postEmbedResponse)
+
+    const post = await Post.find(1)
+    expect(post).toEqual(postEmbedResponse.data)
+    expect(post).toBeInstanceOf(Post)
+  })
+
   test('get() method returns a array of objects as instance of suchModel', async () => {
     axiosMock.onGet('http://localhost/posts').reply(200, postsResponse)
 


### PR DESCRIPTION
This pull request is to handle request to JSON API’s with and without data wrapping.
Basically you only need to configure your model and define how your data is wrapper in each response operation.

## Configration
You only need to define de value of ``dataWrappers()``  
By default, all models operate without data wrapping, for backward compatibility.
```javascript
  dataWrappers() {
    return {
      index: null,
      store: null,
      show: null,
      update: null,
      destroy: null,
    }
  }
```
So, if your API returns all your data inside a ``data`` attribute, then you should set up ``dataWrappers()`` like this:
```javascript
  dataWrappers() {
    return {
      index: 'data',
      store: 'data',
      show: 'data',
      update: 'data',
      destroy: 'data',
    }
  }
```
In case your API only wraps the resources collections, then, you only need to set up that response type:
 ```javascript
  dataWrappers() {
    return {
      index: 'data',
      store: null,
      show: null,
      update: null,
      destroy: null,
    }
  }
```
Well, you get the idea...

## Model Instance hydration
Another thing this pull request solves is the model hydratation. All models will be hydratated after each CRUD operation. This is usefull if your API returns a full representation of the resource. This avoids a second request to get the new values. 
 ```javascript
  // resource before request
  // {
  //   id: 1,
  //   username: 'arya'
  //   email: 'arya.stark@winterfell.com'
  //   token: '1234'
  // }

  // PUT /users/1
  let user = new User({ id: 1, email: 'arya@sevenkingdoms.com' })
  await user.save()

  // response from API for PUT /users/1
  // {
  //   data: {
  //     id: 1,
  //     username: 'arya'
  //     email: 'arya@sevenkingdoms.com'
  //     token: '1234'
  //   }
  // }

  user = {
    id: 1,
    username: 'arya'
    email: 'arya@sevenkingdoms.com'
    token: '1234'
  }
```
This is very useful even for a `DELETE` request, if you return the deleted values.

## Access to response instance on save.
Finally, now, method ``save()`` returns the response instance unmodified. The models are stored in the instance itself (hydrated), but the returned value is the http response. Again, this is useful if we want to access metadata information in the response data.
```javascript
  let user = new User({name: 'Arya'})
  res = user.save()

  // "user" is the User Instance
  user = {
    id: 1,
    name: 'arya',
  }

  // "res" is the http response
  res = {  
    data: {},
    status: 200,
    statusText: 'OK',
    headers: {},
    config: {},
    request: {}  
  }
```

## Tests...
I've added test for all the cases (I think). By the way, I added some "deprecated" comments (in tests) for methods ``$get()``, ``$first()``, ``$find()`` as I think those methods are redundant now? I don't know, what do you think? 
