### PR TITLE
Reset the uri at the start of generatig a query. Fixes issue #92

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -13,6 +13,8 @@ export default class Parser {
 
   // final query string
   query() {
+    this.uri = ''
+
     this.includes()
     this.appends()
     this.fields()

--- a/tests/builder.test.js
+++ b/tests/builder.test.js
@@ -198,4 +198,15 @@ describe('Query builder', () => {
 
     expect(errorModel).toThrow('You must pass a payload/object as param.')
   })
+
+  test('it resets the uri upon query generation when the query is regenerated a second time', () => {
+    const post = Post
+      .where('title', 'Cool')
+      .page(3)
+
+    const query = '?filter[title]=Cool&page=3'
+
+    expect(post._builder.query()).toEqual(query)
+    expect(post._builder.query()).toEqual(query)
+  })
 })


### PR DESCRIPTION
I first created the test to prove the issue, which indeed failed:

```
 FAIL  tests/builder.test.js
  ● Query builder › it resets the uri upon query generation when the query is regenerated a second time

    expect(received).toEqual(expected) // deep equality

    Expected: "?filter[title]=Cool&page=3"
    Received: "?filter[title]=Cool&page=3&filter[title]=Cool&page=3"

      208 | 
      209 |     expect(post._builder.query()).toEqual(query)
    > 210 |     expect(post._builder.query()).toEqual(query)
          |                                   ^
      211 |   })
      212 | })

      at Object.<anonymous> (tests/builder.test.js:210:35)
```

I then added the `this.uri = ''` line to the Parser.js, which made the test pass as expected.

This should solve issue #92 

Thanks for your hard work on this awesome project!