### PR TITLE
check if id is not null

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -133,7 +133,7 @@ export default class Model extends StaticModel {
   }
 
   isValidId(id) {
-    return id !== undefined && id !== 0 && id !== ''
+    return id !== undefined && id !== 0 && id !== '' && id !== null
   }
 
   endpoint() {

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -260,6 +260,22 @@ describe('Model methods', () => {
     comment.save()
   })
 
+  test('save() method makes a POST request when ID of object is null', async () => {
+    let post
+
+    axiosMock.onAny().reply((config) => {
+      expect(config.method).toEqual('post')
+      expect(config.data).toEqual(JSON.stringify(post))
+      expect(config.url).toEqual('http://localhost/posts')
+
+      return [200, {}]
+    })
+
+    post = new Post({ id: null, title: 'Cool!' })
+    await post.save()
+
+  })
+
   test('a request from delete() method hits the right resource', async () => {
 
     axiosMock.onAny().reply((config) => {


### PR DESCRIPTION
When an entity is being saved, nulls are considered as existing entities, so it tries to update and not insert