### PR TITLE
docs(query builder): fix example of `append` 

### DIFF
--- a/docs/content/en/api/query-builder-methods.md
+++ b/docs/content/en/api/query-builder-methods.md
@@ -22,7 +22,7 @@ await Model.include('user', 'category')
 Append attributes.
 
 ```js
-await Model.include('likes')
+await Model.append('likes')
 ```
 
 ## `select`


### PR DESCRIPTION
I was browsing the new docs (great job!) and I just notice this typo in the example. I think you mean append instead of include. :)