### PR TITLE
fix(model): throw an error if operations are used with `custom` 

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -436,6 +436,10 @@ export default class Model extends StaticModel {
   }
 
   save() {
+    if (this._customResource) {
+      throw Error("The save() method cannot be used in conjunction with the custom() method.")
+    }
+
     return this.hasId() ? this._update() : this._create()
   }
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -424,7 +424,7 @@ export default class Model extends StaticModel {
 
   delete() {
     if (this._customResource) {
-      throw Error("The delete() method cannot be used in conjunction with the custom() method.")
+      throw Error("The delete() method cannot be used in conjunction with the custom() method. Use for() instead.")
     }
 
     if (!this.hasId()) {
@@ -441,7 +441,7 @@ export default class Model extends StaticModel {
 
   save() {
     if (this._customResource) {
-      throw Error("The save() method cannot be used in conjunction with the custom() method.")
+      throw Error("The save() method cannot be used in conjunction with the custom() method. Use for() instead.")
     }
 
     return this.hasId() ? this._update() : this._create()
@@ -481,7 +481,7 @@ export default class Model extends StaticModel {
 
   attach(params) {
     if (this._customResource) {
-      throw Error("The attach() method cannot be used in conjunction with the custom() method.")
+      throw Error("The attach() method cannot be used in conjunction with the custom() method. Use for() instead.")
     }
 
     return this.request(
@@ -495,7 +495,7 @@ export default class Model extends StaticModel {
 
   sync(params) {
     if (this._customResource) {
-      throw Error("The sync() method cannot be used in conjunction with the custom() method.")
+      throw Error("The sync() method cannot be used in conjunction with the custom() method. Use for() instead.")
     }
 
     return this.request(

--- a/src/Model.js
+++ b/src/Model.js
@@ -423,6 +423,10 @@ export default class Model extends StaticModel {
    */
 
   delete() {
+    if (this._customResource) {
+      throw Error("The delete() method cannot be used in conjunction with the custom() method.")
+    }
+
     if (!this.hasId()) {
       throw new Error('This model has a empty ID.')
     }
@@ -476,6 +480,10 @@ export default class Model extends StaticModel {
    */
 
   attach(params) {
+    if (this._customResource) {
+      throw Error("The attach() method cannot be used in conjunction with the custom() method.")
+    }
+
     return this.request(
       this._reqConfig({
         method: 'POST',
@@ -486,6 +494,10 @@ export default class Model extends StaticModel {
   }
 
   sync(params) {
+    if (this._customResource) {
+      throw Error("The sync() method cannot be used in conjunction with the custom() method.")
+    }
+
     return this.request(
       this._reqConfig({
         method: 'PUT',

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -960,6 +960,14 @@ describe('Model methods', () => {
     expect(errorModel).toThrow('Arguments to custom() must be strings or instances of Model.')
   })
 
+  test('it throws an error when save() is used in conjunction with custom()', () => {
+    errorModel = () => {
+      const post = new Post({ text: 'Hello' }).custom('foo/bar').save()
+    }
+
+    expect(errorModel).toThrow("The save() method cannot be used in conjunction with the custom() method.")
+  })
+
   test('save() method makes a PUT request to the correct URL on nested object thas was fetched with find() method', async () => {
     axiosMock.onGet('http://localhost/posts/1/comments/1').reply(200, commentsResponse[0])
     axiosMock.onPut('http://localhost/posts/1/comments/1').reply(200, commentsResponse[0])

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -965,13 +965,13 @@ describe('Model methods', () => {
       const post = new Post({ text: 'Hello' }).custom('foo/bar').save()
     }
 
-    expect(errorModel).toThrow("The save() method cannot be used in conjunction with the custom() method.")
+    expect(errorModel).toThrow("The save() method cannot be used in conjunction with the custom() method. Use for() instead.")
 
     errorModel = () => {
       const post = new Post({ id: 1 }).custom('foo/bar').delete()
     }
 
-    expect(errorModel).toThrow("The delete() method cannot be used in conjunction with the custom() method.")
+    expect(errorModel).toThrow("The delete() method cannot be used in conjunction with the custom() method. Use for() instead.")
 
     errorModel = () => {
       const post = new Post({ id: 1 })
@@ -980,7 +980,7 @@ describe('Model methods', () => {
       })
     }
 
-    expect(errorModel).toThrow("The attach() method cannot be used in conjunction with the custom() method.")
+    expect(errorModel).toThrow("The attach() method cannot be used in conjunction with the custom() method. Use for() instead.")
 
     errorModel = () => {
       const post = new Post({ id: 1 })
@@ -989,7 +989,7 @@ describe('Model methods', () => {
       })
     }
 
-    expect(errorModel).toThrow("The sync() method cannot be used in conjunction with the custom() method.")
+    expect(errorModel).toThrow("The sync() method cannot be used in conjunction with the custom() method. Use for() instead.")
   })
 
   test('save() method makes a PUT request to the correct URL on nested object thas was fetched with find() method', async () => {

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -960,12 +960,36 @@ describe('Model methods', () => {
     expect(errorModel).toThrow('Arguments to custom() must be strings or instances of Model.')
   })
 
-  test('it throws an error when save() is used in conjunction with custom()', () => {
+  test('it throws an error when CRUD and relationship operations are used in conjunction with custom()', () => {
     errorModel = () => {
       const post = new Post({ text: 'Hello' }).custom('foo/bar').save()
     }
 
     expect(errorModel).toThrow("The save() method cannot be used in conjunction with the custom() method.")
+
+    errorModel = () => {
+      const post = new Post({ id: 1 }).custom('foo/bar').delete()
+    }
+
+    expect(errorModel).toThrow("The delete() method cannot be used in conjunction with the custom() method.")
+
+    errorModel = () => {
+      const post = new Post({ id: 1 })
+      const comment = post.comments().custom('foo/bar').attach({
+        text: 'Awesome post!'
+      })
+    }
+
+    expect(errorModel).toThrow("The attach() method cannot be used in conjunction with the custom() method.")
+
+    errorModel = () => {
+      const post = new Post({ id: 1 })
+      const comment = post.comments().custom('foo/bar').sync({
+        text: 'Awesome post!'
+      })
+    }
+
+    expect(errorModel).toThrow("The sync() method cannot be used in conjunction with the custom() method.")
   })
 
   test('save() method makes a PUT request to the correct URL on nested object thas was fetched with find() method', async () => {


### PR DESCRIPTION
Throw an error if CRUD or relationship operations are used in in conjunction with the `custom` method.

Fixes #172 