### PR TITLE
ci: update test-and-release workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -5,14 +5,48 @@ name: Test and Release
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [
+        master,
+        dev,
+        alpha,
+        beta,
+        next,
+        next-major
+    ]
 
   pull_request:
-    branches: [ master, dev ]
+    branches: [
+        master,
+        dev,
+        alpha,
+        beta,
+        next,
+        next-major
+    ]
 
 jobs:
+  pre_job:
+    name: Pre Job
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          github_token: ${{ github.token }}
+          paths_ignore: '["**/*.md", ".releaserc", ".editorconfig", ".gitignore", ".eslintignore", ".prettierignore", "docs/**", ".github/**"]'
+          do_not_skip: '["workflow_dispatch", "schedule"]'
+
   test:
     name: Test
+
+    needs: pre_job
+
+    if: needs.pre_job.outputs.should_skip != 'true' || (github.ref != 'refs/heads/dev' && github.head_ref != 'dev' && github.base_ref != 'dev')
 
     runs-on: ${{ matrix.os }}
 
@@ -55,7 +89,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push'
 
     strategy:
       matrix:


### PR DESCRIPTION
- Skip unnecessary tests (like tests of this PR :P)
- Enable `alpha`, `beta`, `next` and `next-major` releases for their respective branches