### PR TITLE
feat(model): improve request config

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -38,7 +38,8 @@ export default class Model extends StaticModel {
   }
 
   config(config) {
-    this._config = config
+    Object.defineProperty(this, '_config', { get: () => config })
+
     return this
   }
 
@@ -313,11 +314,6 @@ export default class Model extends StaticModel {
 
     // Check if config has data
     if ('data' in _config) {
-      // Ditch private data
-      _config.data = Object.fromEntries(
-        Object.entries(_config.data).filter(([key]) => !key.startsWith('_'))
-      )
-
       const _hasFiles = Object.keys(_config.data).some((property) => {
         if (Array.isArray(_config.data[property])) {
           return _config.data[property].some((value) => value instanceof File)

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -414,7 +414,6 @@ describe('Model methods', () => {
 
     axiosMock.onAny().reply((config) => {
       const _post = post
-      delete _post._config
 
       expect(config.method).toEqual('patch')
       expect(config.data).toEqual(JSON.stringify(_post))
@@ -452,7 +451,6 @@ describe('Model methods', () => {
 
     axiosMock.onAny().reply((config) => {
       const _post = post
-      delete _post._config
 
       expect(config.method).toEqual('post')
       expect(config.data).toEqual(JSON.stringify(_post))
@@ -572,7 +570,6 @@ describe('Model methods', () => {
     axiosMock.onAny().reply((config) => {
       let _data
       const _post = post
-      delete _post._config
 
       if (config.headers['Content-Type'] === 'multipart/form-data') {
         _data = Object.fromEntries(config.data)
@@ -634,7 +631,6 @@ describe('Model methods', () => {
     axiosMock.onAny().reply((config) => {
       let _data
       const _post = post
-      delete _post._config
 
       if (config.headers['Content-Type'] === 'multipart/form-data') {
         _data = JSON.stringify(Object.fromEntries(config.data))


### PR DESCRIPTION
Use `Object.defineProperty` to set `_config`. This way we don't need to ditch private data anymore.

Closes #180 