### PR TITLE
feat(model): add method parserOptions

### DIFF
--- a/docs/content/en/api/model-options.md
+++ b/docs/content/en/api/model-options.md
@@ -111,6 +111,27 @@ formData() {
 }
 ```
 
+### `parserOptions`
+- Returns: `object`
+
+This method can be overridden in the model to customize the the array format encoding options.
+
+Possible values are: indices, brackets, repeat, comma.
+
+See [Configuration](/configuration#customizing-query-parameters)
+
+```js
+parserOptions() {
+  return {
+    arrayFormat: 'comma',
+  }
+}
+```
+
+#### `arrayFormat`
+- Default: `comma`
+- Returns: `string`
+
 ## Model Options
 
 These are model-related options.

--- a/index.d.ts
+++ b/index.d.ts
@@ -444,6 +444,16 @@ export class Model extends StaticModel {
   }
 
   /**
+   * This method can be overridden in the model to customize the the array format encoding options.
+   *
+   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#parseroptions|API Reference}
+   * @see {@link https://robsontenorio.github.io/vue-api-query/configuration#customizing-query-parameters|Configuration}
+   */
+   protected parserOptions (): {
+    arrayFormat: string
+  }
+
+  /**
    * Query
    */
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -188,6 +188,12 @@ export default class Model extends StaticModel {
     }
   }
 
+  parserOptions() {
+    return {
+      arrayFormat: 'comma',
+    }
+  }
+
   /**
    *  Query
    */

--- a/src/Model.js
+++ b/src/Model.js
@@ -190,7 +190,7 @@ export default class Model extends StaticModel {
 
   parserOptions() {
     return {
-      arrayFormat: 'comma',
+      arrayFormat: 'comma'
     }
   }
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -106,7 +106,10 @@ export default class Parser {
     let fields = { [this.parameterNames().fields]: this.builder.fields }
     this.uri +=
       this.prepend() +
-      qs.stringify(fields, { encode: false, arrayFormat: this.builder.model.parserOptions().arrayFormat })
+      qs.stringify(fields, {
+        encode: false,
+        arrayFormat: this.builder.model.parserOptions().arrayFormat
+      })
   }
 
   filters() {
@@ -117,7 +120,10 @@ export default class Parser {
     let filters = { [this.parameterNames().filter]: this.builder.filters }
     this.uri +=
       this.prepend() +
-      qs.stringify(filters, { encode: false, arrayFormat: this.builder.model.parserOptions().arrayFormat })
+      qs.stringify(filters, {
+        encode: false,
+        arrayFormat: this.builder.model.parserOptions().arrayFormat
+      })
   }
 
   sorts() {

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -106,7 +106,7 @@ export default class Parser {
     let fields = { [this.parameterNames().fields]: this.builder.fields }
     this.uri +=
       this.prepend() +
-      qs.stringify(fields, { encode: false, arrayFormat: 'comma' })
+      qs.stringify(fields, { encode: false, arrayFormat: this.builder.model.parserOptions().arrayFormat })
   }
 
   filters() {
@@ -117,7 +117,7 @@ export default class Parser {
     let filters = { [this.parameterNames().filter]: this.builder.filters }
     this.uri +=
       this.prepend() +
-      qs.stringify(filters, { encode: false, arrayFormat: 'comma' })
+      qs.stringify(filters, { encode: false, arrayFormat: this.builder.model.parserOptions().arrayFormat })
   }
 
   sorts() {

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -165,7 +165,7 @@ export default class Parser {
       this.prepend() +
       qs.stringify(this.builder.payload, {
         encode: false,
-        arrayFormat: 'comma'
+        arrayFormat: this.builder.model.parserOptions().arrayFormat
       })
   }
 }

--- a/tests/builder.test.js
+++ b/tests/builder.test.js
@@ -58,11 +58,12 @@ describe('Query builder', () => {
   })
 
   test('it can change default array format option', () => {
-    const post = PostWithOptions.include('user')
-      .whereIn('title', ['Cool', 'Lame'])
+    const post = PostWithOptions.include('user').whereIn('title', [
+      'Cool',
+      'Lame'
+    ])
 
-    const query =
-      '?include=user&filter[title][0]=Cool&filter[title][1]=Lame'
+    const query = '?include=user&filter[title][0]=Cool&filter[title][1]=Lame'
 
     expect(post._builder.query()).toEqual(query)
 

--- a/tests/builder.test.js
+++ b/tests/builder.test.js
@@ -4,6 +4,7 @@ import MockAdapter from 'axios-mock-adapter'
 import { Model } from '../src'
 import ModelWithParamNames from './dummy/models/ModelWithParamNames'
 import Post from './dummy/models/Post'
+import PostWithOptions from './dummy/models/PostWithOptions'
 
 describe('Query builder', () => {
   let errorModel = {}
@@ -54,6 +55,20 @@ describe('Query builder', () => {
       '?include_custom=user&append_custom=likes&fields_custom[posts]=title,content&fields_custom[user]=age,firstname&filter_custom[title]=Cool&filter_custom[status]=ACTIVE&sort_custom=created_at&page_custom=3&limit_custom=10'
 
     expect(post._builder.query()).toEqual(query)
+  })
+
+  test('it can change default array format option', () => {
+    const post = PostWithOptions.include('user')
+      .whereIn('title', ['Cool', 'Lame'])
+
+    const query =
+      '?include=user&filter[title][0]=Cool&filter[title][1]=Lame'
+
+    expect(post._builder.query()).toEqual(query)
+
+    expect(post._builder.filters).toEqual({
+      title: ['Cool', 'Lame']
+    })
   })
 
   test('include() sets properly the builder', () => {

--- a/tests/dummy/models/PostWithOptions.js
+++ b/tests/dummy/models/PostWithOptions.js
@@ -1,0 +1,23 @@
+import BaseModel from './BaseModel'
+import Comment from './Comment'
+import Tag from './Tag'
+import User from './User'
+
+export default class PostWithOptions extends BaseModel {
+  comments() {
+    return this.hasMany(Comment)
+  }
+
+  relations() {
+    return {
+      user: User,
+      'relationships.tags': Tag
+    }
+  }
+
+  parserOptions() {
+    return {
+      arrayFormat: 'indices'
+    }
+  }
+}


### PR DESCRIPTION
Add a way to customise parser options.

Some frameworks, like Laravel, expect the array to be encoded with indices format instead of comma format.

This will allow to set a different option while respecting the current default.

See: https://github.com/robsontenorio/vue-api-query/issues/214#issuecomment-1212869506

Added tests and docs.


