### PR TITLE
chore(deps): bump defu version to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "semantic-release": "^19.0.3"
   },
   "dependencies": {
-    "defu": "^5.0.0",
+    "defu": "^6.0.0",
     "dotprop": "^1.2.0",
     "dset": "^3.1.2",
     "object-to-formdata": "^4.1.0",

--- a/src/Model.js
+++ b/src/Model.js
@@ -1,4 +1,4 @@
-import defu from 'defu'
+import { defu } from 'defu'
 import getProp from 'dotprop'
 import { dset as setProp } from 'dset'
 import { serialize } from 'object-to-formdata'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2642,10 +2642,10 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-defu@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/defu/-/defu-5.0.0.tgz#5768f0d402a555bfc4c267246b20f82ce8b5a10b"
-  integrity sha512-VHg73EDeRXlu7oYWRmmrNp/nl7QkdXUxkQQKig0Zk8daNmm84AbGoC8Be6/VVLJEKxn12hR0UBmz8O+xQiAPKQ==
+defu@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.0.tgz#7a5411655da73335c7d933256911f17c74443e2d"
+  integrity sha512-pOFYRTIhoKujrmbTRhcW5lYQLBXw/dlTwfI8IguF1QCDJOcJzNH1w+YFjxqy6BAuJrClTy6MUE8q+oKJ2FLsIw==
 
 del@^6.0.0:
   version "6.1.1"


### PR DESCRIPTION
Bump defu version to 6.0.0 to fix nuxt3 related error (cannot find module ../defu.cjs)

## Checklist

- [ ] Tests
- [ ] Docs
- [ ] Type definitions 
