### PR TITLE
docs(api): add url parameter to `config` method

### DIFF
--- a/docs/content/en/api/query-builder-methods.md
+++ b/docs/content/en/api/query-builder-methods.md
@@ -243,6 +243,7 @@ Configuration of HTTP Instance.
 ```js
 await Model.config({
   method: 'PATCH',
+  url: 'foo-bar',
   header: { /* ... */ },
   data: { foo: 'bar' }
 }).save()


### PR DESCRIPTION
## Checklist

- [ ] Tests
- [ ] Docs
- [ ] Type definitions 
